### PR TITLE
fix: add glob-star for object-level actions

### DIFF
--- a/tf_files-1.0/aws/modules/rds/data.tf
+++ b/tf_files-1.0/aws/modules/rds/data.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "backup_bucket_access_kms" {
 
   statement {
     actions = ["s3:GetObject","s3:PutObject","s3:ListMultipartUploadParts","s3:AbortMultipartUpload"]
-    resources = ["arn:aws:s3:::${var.rds_instance_backup_bucket_name}"]
+    resources = ["arn:aws:s3:::${var.rds_instance_backup_bucket_name}/*"]
     effect = "Allow"
   }
 }


### PR DESCRIPTION
Jira Ticket: N/A
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
* `GetObject`/`PutObject` needs `/*` to properly grant the permissions to objects, like [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-policies-s3.html#iam-policy-ex0) and [object operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-objects)

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
