### PR TITLE
adding all the cidr blocks to the ingress for the private_es sg

### DIFF
--- a/tf_files/aws/modules/commons-vpc-es/cloud.tf
+++ b/tf_files/aws/modules/commons-vpc-es/cloud.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "private_es" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [data.aws_vpc.the_vpc.cidr_block]
+    cidr_blocks = [local.all_cidr_blocks]
   }
 
   egress {

--- a/tf_files/aws/modules/commons-vpc-es/data.tf
+++ b/tf_files/aws/modules/commons-vpc-es/data.tf
@@ -13,6 +13,10 @@ data "aws_vpc" "the_vpc" {
   id = data.aws_vpcs.vpcs.ids[0]
 }
 
+locals {
+  all_cidr_blocks = [for assoc in data.aws_vpc.the_vpc.cidr_block_association : assoc.cidr_block]
+}
+
 data "aws_iam_user" "es_user" {
   user_name = "${var.vpc_name}_es_user"
 }


### PR DESCRIPTION
Some environments may use a secondary cidr to allow for more nodes to come up, so we need to add this cidr to the private Elasticsearch sg. 