### PR TITLE
Add peregrine creds to deployment

### DIFF
--- a/tf_files/gen3/db.tf
+++ b/tf_files/gen3/db.tf
@@ -94,6 +94,18 @@ module "metadata-db" {
   secrets_manager_enabled = true
 }
 
+module "peregrine-db" {
+  count                   = var.peregrine_enabled ? 1 : 0
+  source                  = "../aws/aurora_db"
+  vpc_name                = var.vpc_name
+  service                 = "peregrine"
+  admin_database_username = var.aurora_username
+  admin_database_password = var.aurora_password
+  namespace               = var.namespace
+  create_db               = var.create_dbs
+  secrets_manager_enabled = true
+}
+
 module "requestor-db" {
   count                   = var.requestor_enabled ? 1 : 0
   source                  = "../aws/aurora_db"

--- a/tf_files/gen3/templates/values.tftpl
+++ b/tf_files/gen3/templates/values.tftpl
@@ -181,7 +181,7 @@ metadata:
 peregrine:
   enabled: ${peregrine_enabled}
   externalSecrets:
-    dbcreds: "${vpc_name}-${namespace}-sheepdg-creds"
+    dbcreds: "${vpc_name}-${namespace}-peregrine-creds"
 
 pidgin:
   enabled: ${pidgin_enabled}


### PR DESCRIPTION
Peregrine was left out of the `db.tf` script in the `gen3` module, so the secret was not getting created.

In addition, the creds reference in the values template was incorrect.
