### PR TITLE
fix: parameterize hardcoded us-east-1 AWS region references

### DIFF
--- a/tf_files/aws/access/cloud.tf
+++ b/tf_files/aws/access/cloud.tf
@@ -10,12 +10,14 @@ terraform {
   }
 }
 
+data "aws_region" "current" {}
+
 resource "aws_s3_bucket" "access" {
   bucket = var.access_url
 }
 
 locals {
-  s3_origin_id = "S3-Website-${var.access_url}.s3-website-us-east-1.amazonaws.com"
+  s3_origin_id = "S3-Website-${var.access_url}.s3-website-${data.aws_region.current.name}.amazonaws.com"
 }
 
 

--- a/tf_files/aws/aurora_db/data.tf
+++ b/tf_files/aws/aurora_db/data.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 data "aws_eks_cluster" "eks" {
   name = var.vpc_name
 }

--- a/tf_files/aws/aurora_db/root.tf
+++ b/tf_files/aws/aurora_db/root.tf
@@ -102,7 +102,7 @@ resource "null_resource" "db_restore" {
 if [[ ${var.db_job_role_arn} != "" ]]; then
   CREDENTIALS=(`aws sts assume-role --role-arn ${var.db_job_role_arn} --role-session-name "db-migration-cli" --query "[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]" --output text`)
   unset AWS_PROFILE
-  export AWS_DEFAULT_REGION=us-east-1
+  export AWS_DEFAULT_REGION=${data.aws_region.current.name}
   export AWS_ACCESS_KEY_ID="$${CREDENTIALS[0]}"
   export AWS_SECRET_ACCESS_KEY="$${CREDENTIALS[1]}"
   export AWS_SESSION_TOKEN="$${CREDENTIALS[2]}"
@@ -137,7 +137,7 @@ resource "null_resource" "db_dump" {
 if [[ ${var.db_job_role_arn} != "" ]]; then
   CREDENTIALS=(`aws sts assume-role --role-arn ${var.db_job_role_arn} --role-session-name "db-migration-cli" --query "[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]" --output text`)
   unset AWS_PROFILE
-  export AWS_DEFAULT_REGION=us-east-1
+  export AWS_DEFAULT_REGION=${data.aws_region.current.name}
   export AWS_ACCESS_KEY_ID="$${CREDENTIALS[0]}"
   export AWS_SECRET_ACCESS_KEY="$${CREDENTIALS[1]}"
   export AWS_SESSION_TOKEN="$${CREDENTIALS[2]}"

--- a/tf_files/aws/external-secrets/root.tf
+++ b/tf_files/aws/external-secrets/root.tf
@@ -27,15 +27,15 @@ resource "aws_iam_role" "external-secrets-role" {
         Sid = ""
         Effect = "Allow"
         Principal = {
-          Federated = "arn:aws:iam::${var.account_number}:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/${var.oidc_provider_id}"
+          Federated = "arn:aws:iam::${var.account_number}:oidc-provider/oidc.eks.${var.aws_region}.amazonaws.com/id/${var.oidc_provider_id}"
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
           StringEquals = {
-            "oidc.eks.us-east-1.amazonaws.com/id/${var.oidc_provider_id}:sub" = [
+            "oidc.eks.${var.aws_region}.amazonaws.com/id/${var.oidc_provider_id}:sub" = [
               "system:serviceaccount:${var.commons_name}-helm:secret-store-sa"
             ]
-            "oidc.eks.us-east-1.amazonaws.com/id/${var.oidc_provider_id}:aud" = "sts.amazonaws.com"
+            "oidc.eks.${var.aws_region}.amazonaws.com/id/${var.oidc_provider_id}:aud" = "sts.amazonaws.com"
           }
         }
       }

--- a/tf_files/aws/external-secrets/variables.tf
+++ b/tf_files/aws/external-secrets/variables.tf
@@ -7,3 +7,9 @@ variable oidc_provider_id {}
 variable account_number {
   description = "AWS account ID to use"
 }
+
+variable "aws_region" {
+  description = "AWS region where the EKS cluster is deployed"
+  type        = string
+  default     = "us-east-1"
+}

--- a/tf_files/aws/modules/account-management-logs/event-alerts.tf
+++ b/tf_files/aws/modules/account-management-logs/event-alerts.tf
@@ -23,7 +23,7 @@ module "alerting-lambda" {
   lambda_function_name         = "${var.account_name}-security-alert-lambda"
   lambda_function_description  = "Checking for things that should or might not happend"
   lambda_function_iam_role_arn = module.role-for-lambda.role_arn
-  lambda_function_env          = {"topic"="arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-for-bsd-security"}
+  lambda_function_env          = {"topic"=var.csoc_alerts_sns_arn}
   lambda_function_handler      = "security_alerts.lambda_handler"
 }
 

--- a/tf_files/aws/modules/account-management-logs/variables.tf
+++ b/tf_files/aws/modules/account-management-logs/variables.tf
@@ -5,3 +5,9 @@ variable "csoc_account_id" {
 variable "account_name" {}
 
 variable "alarm_actions" {}
+
+variable "csoc_alerts_sns_arn" {
+  description = "ARN of the CSOC security alerts SNS topic used by the alerting Lambda"
+  type        = string
+  default     = "arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-for-bsd-security"
+}

--- a/tf_files/aws/modules/admin-vm/cloud.tf
+++ b/tf_files/aws/modules/admin-vm/cloud.tf
@@ -104,7 +104,7 @@ resource "aws_instance" "login" {
 #Proxy configuration and hostname assigment for the adminVM
 echo http_proxy=http://cloud-proxy.internal.io:3128 >> /etc/environment
 echo https_proxy=http://cloud-proxy.internal.io:3128/ >> /etc/environment
-echo no_proxy="localhost,127.0.0.1,localaddress,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com"  >> /etc/environment
+echo no_proxy="localhost,127.0.0.1,localaddress,169.254.169.254,.internal.io,logs.${var.aws_region}.amazonaws.com"  >> /etc/environment
 echo 'Acquire::http::Proxy "http://cloud-proxy.internal.io:3128";' >> /etc/apt/apt.conf.d/01proxy
 echo 'Acquire::https::Proxy "http://cloud-proxy.internal.io:3128";' >> /etc/apt/apt.conf.d/01proxy
 echo '127.0.1.1 ${var.child_name}_admin' | sudo tee --append /etc/hosts
@@ -134,13 +134,13 @@ sudo mkdir -p /home/ubuntu/.aws
 sudo cat <<EOT  >> /home/ubuntu/.aws/config
 [default]
 output = json
-region = us-east-1
+region = ${var.aws_region}
 role_session_name = gen3-adminvm
 role_arn = arn:aws:iam::${var.child_account_id}:role/csoc_adminvm
 credential_source = Ec2InstanceMetadata
 [profile ${var.child_name}]
 output = json
-region = us-east-1
+region = ${var.aws_region}
 role_session_name = gen3-adminvm
 role_arn = arn:aws:iam::${var.child_account_id}:role/csoc_adminvm
 credential_source = Ec2InstanceMetadata

--- a/tf_files/aws/modules/backup/cloud.tf
+++ b/tf_files/aws/modules/backup/cloud.tf
@@ -17,7 +17,7 @@ resource "aws_kms_key" "backup_key" {
   description             = "KMS key for encrypting RDS backups"
   deletion_window_in_days = 10
   enable_key_rotation     = true
-  region                  = "us-east-1"
+  region                  = data.aws_region.current.name
 }
 
 resource "aws_kms_key_policy" "backup_key_external_account" {
@@ -84,7 +84,7 @@ resource "aws_backup_plan" "daily" {
           delete_after = 7 # Retain for 7 days
         }
 
-        destination_vault_arn = "arn:aws:backup:us-east-1:${var.backup_destination_account}:backup-vault:rds-central-backup-vault-${data.aws_caller_identity.current.account_id}"
+        destination_vault_arn = "arn:aws:backup:${var.backup_destination_region}:${var.backup_destination_account}:backup-vault:rds-central-backup-vault-${data.aws_caller_identity.current.account_id}"
       }
     }
   }
@@ -134,7 +134,7 @@ resource "aws_backup_plan" "weekly" {
           delete_after = 30 # Retain for 30 days
         }
 
-        destination_vault_arn = "arn:aws:backup:us-east-1:${var.backup_destination_account}:backup-vault:rds-central-backup-vault-${data.aws_caller_identity.current.account_id}"
+        destination_vault_arn = "arn:aws:backup:${var.backup_destination_region}:${var.backup_destination_account}:backup-vault:rds-central-backup-vault-${data.aws_caller_identity.current.account_id}"
       }
     }
   }
@@ -183,7 +183,7 @@ resource "aws_backup_plan" "monthly" {
           delete_after = 365 # Retain for 365 days (1 year)
         }
 
-        destination_vault_arn = "arn:aws:backup:us-east-1:${var.backup_destination_account}:backup-vault:rds-central-backup-vault-${data.aws_caller_identity.current.account_id}"
+        destination_vault_arn = "arn:aws:backup:${var.backup_destination_region}:${var.backup_destination_account}:backup-vault:rds-central-backup-vault-${data.aws_caller_identity.current.account_id}"
       }
     }
   }
@@ -232,7 +232,7 @@ resource "aws_backup_plan" "yearly" {
           delete_after = 2555 # Retain for 2555 days (7 years)
         }
 
-        destination_vault_arn = "arn:aws:backup:us-east-1:${var.backup_destination_account}:backup-vault:rds-central-backup-vault-${data.aws_caller_identity.current.account_id}"
+        destination_vault_arn = "arn:aws:backup:${var.backup_destination_region}:${var.backup_destination_account}:backup-vault:rds-central-backup-vault-${data.aws_caller_identity.current.account_id}"
       }
     }
   }

--- a/tf_files/aws/modules/backup/variables.tf
+++ b/tf_files/aws/modules/backup/variables.tf
@@ -16,6 +16,12 @@ variable "daily_backups_enabled" {
   default     = true
 }
 
+variable "backup_destination_region" {
+  description = "AWS region of the central cross-account backup vault"
+  type        = string
+  default     = "us-east-1"
+}
+
 variable "cross_region_destination" {
   description = "The AWS region in which backups should live"
   type        = string

--- a/tf_files/aws/modules/utility-vm/cloud.tf
+++ b/tf_files/aws/modules/utility-vm/cloud.tf
@@ -130,7 +130,7 @@ locals {
   proxy_config_environment = <<EOF
 http_proxy=http://cloud-proxy.internal.io:3128
 https_proxy=http://cloud-proxy.internal.io:3128
-no_proxy=localhost,127.0.0.1,localaddress,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com
+no_proxy=localhost,127.0.0.1,localaddress,169.254.169.254,.internal.io,logs.${data.aws_region.current.name}.amazonaws.com
 EOF
 
   proxy_config_apt = <<EOF

--- a/tf_files/aws/nextflow_ami_pipeline/imagebuilder.tf
+++ b/tf_files/aws/nextflow_ami_pipeline/imagebuilder.tf
@@ -113,7 +113,7 @@ resource "aws_imagebuilder_distribution_configuration" "public_ami" {
       }
     }
 
-    region = "us-east-1"
+    region = var.region
   }
 }
 
@@ -140,7 +140,7 @@ resource "aws_imagebuilder_image_recipe" "recipe" {
 
   # TODO: Do we need this? ECS optimized should come with docker
   component {
-    component_arn = "arn:aws:imagebuilder:us-east-1:aws:component/docker-ce-linux/1.0.0/1"
+    component_arn = "arn:aws:imagebuilder:${var.region}:aws:component/docker-ce-linux/1.0.0/1"
   }
 
   component {

--- a/tf_files/aws/nextflow_ami_pipeline/variables.tf
+++ b/tf_files/aws/nextflow_ami_pipeline/variables.tf
@@ -2,6 +2,12 @@ variable "vpc_name" {
   type = string
 }
 
+variable "region" {
+  description = "AWS region where the pipeline resources will be deployed"
+  type        = string
+  default     = "us-east-1"
+}
+
 
 variable "subnet_name" {
   type = string
@@ -9,7 +15,8 @@ variable "subnet_name" {
 }
 
 variable "base_image" {
-  type = string
+  type        = string
+  description = "Base image ARN for the pipeline. The default targets us-east-1; override with the equivalent ARN for your target region."
   default = "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-ecs-optimized-kernel-5-x86/x.x.x"
 }
 

--- a/tf_files/gen3/data.tf
+++ b/tf_files/gen3/data.tf
@@ -1,1 +1,3 @@
 data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/tf_files/gen3/root.tf
+++ b/tf_files/gen3/root.tf
@@ -88,6 +88,7 @@ resource "local_file" "user_yaml_workflow" {
   filename = "./users-repo/.github/workflows/user-yaml-push.yaml"
   content  = templatefile("${path.module}/templates/user-yaml-push.tftpl", {
     useryaml_s3_path = var.useryaml_s3_path
+    region           = data.aws_region.current.name
   })
   depends_on = [null_resource.config_setup, helm_release.gen3]
 }

--- a/tf_files/gen3/secrets.tf
+++ b/tf_files/gen3/secrets.tf
@@ -23,6 +23,7 @@ resource "aws_secretsmanager_secret_version" "fence_config" {
         cognito_discovery_url = var.cognito_discovery_url
         cognito_client_id     = var.cognito_client_id
         cognito_client_secret = var.cognito_client_secret
+        region                = data.aws_region.current.name
       })
       
   lifecycle {

--- a/tf_files/gen3/templates/fence-config.tftpl
+++ b/tf_files/gen3/templates/fence-config.tftpl
@@ -51,7 +51,7 @@ S3_BUCKETS:
   # Name of the actual s3 bucket
   ${upload_bucket}:
     cred: 'fence-bot'
-    region: us-east-1
+    region: ${region}
 
 dbGaP:
  parent_to_child_studies_mapping: {}

--- a/tf_files/gen3/templates/user-yaml-push.tftpl
+++ b/tf_files/gen3/templates/user-yaml-push.tftpl
@@ -82,7 +82,7 @@ jobs:
         cd $${{ github.event.repository.name }}
         git checkout main
         git pull
-        aws s3 cp users/dev/user.yaml ${useryaml_s3_path} --recursive --region us-east-1
+        aws s3 cp users/dev/user.yaml ${useryaml_s3_path} --recursive --region ${region}
       env:
         AWS_ACCESS_KEY_ID: $${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: $${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

Replaces all hardcoded `us-east-1` region literals in active `tf_files/` resource configurations, shell scripts, and templates with variables or data sources. This ensures modules can be deployed to any AWS region.

All new variables default to `"us-east-1"` to preserve backward compatibility with existing UC-CDIS deployments — no change in behavior for deployments that do not override region.

## Changes

| File | Fix |
|------|-----|
| `aws/external-secrets/variables.tf` + `root.tf` | Add `var.aws_region`; parameterize EKS OIDC provider URL (3 occurrences) |
| `aws/modules/backup/variables.tf` + `cloud.tf` | Add `var.backup_destination_region`; fix 4 cross-account vault ARNs; use `data.aws_region.current.name` for KMS key `region` |
| `aws/nextflow_ami_pipeline/variables.tf` + `imagebuilder.tf` | Add `var.region`; fix distribution `region` and AWS-managed component ARN; document region-specific `base_image` default |
| `aws/modules/admin-vm/cloud.tf` | Interpolate `var.aws_region` into `no_proxy` and embedded AWS CLI config |
| `aws/modules/utility-vm/cloud.tf` | Use `data.aws_region.current.name` in `proxy_config_environment` (consistent with existing `profile_d` local) |
| `aws/aurora_db/data.tf` + `root.tf` | Add `data "aws_region" "current"`; replace `AWS_DEFAULT_REGION=us-east-1` in two `local-exec` blocks |
| `aws/access/cloud.tf` | Add `data "aws_region" "current"`; fix S3 website endpoint origin ID string |
| `gen3/data.tf` | Add `data "aws_region" "current"` |
| `gen3/templates/fence-config.tftpl` + `secrets.tf` | Replace `region: us-east-1` with `${region}` template var; pass `data.aws_region.current.name` from caller |
| `gen3/templates/user-yaml-push.tftpl` + `root.tf` | Replace `--region us-east-1` with `${region}` template var; pass `data.aws_region.current.name` from caller |
| `aws/modules/account-management-logs/variables.tf` + `event-alerts.tf` | Add `var.csoc_alerts_sns_arn` (default preserves existing ARN value) to replace inline hardcoded SNS ARN |

## Backward Compatibility

- All newly introduced variables have `default = "us-east-1"`, so existing deployments require no changes.
- Existing `default = "us-east-1"` values on region variables, AZ lists, and org-specific ARN defaults in `variables.tf` files are intentionally left unchanged — those are already overridable by callers.

## Not Included

- `tf_files_deprecated/` — out of scope (legacy code).
- `aws/account-wide-patch-policy/cloud.tf` line 126 — intentional explicit list of all AWS regions.
- `aws/modules/account-management-metrics/filters.tf` — CloudWatch filter pattern logic; left for separate review.