### PR TITLE
BUGFIX: Pass custom users.yaml bucket name to commons module

### DIFF
--- a/examples/gen3-deployment/main.tf
+++ b/examples/gen3-deployment/main.tf
@@ -93,6 +93,7 @@ module "commons" {
   deploy_indexd_db               = false
   network_expansion              = true
   users_policy                   = "dev"
+  users_bucket_name              = local.user_yaml_bucket_name
   availability_zones             = local.availability_zones
   es_version                     = "7.10"
   es_linked_role                 = local.es_linked_role


### PR DESCRIPTION
# Problem
When deploying the example project in `examples/gen3-deployment` the users bucket name can be configured in the _locals_ section, but this config is not passed to the _commons_ aws infra module:

```
user_yaml_bucket_name = "<update with your user yaml bucket name>"
```

This results in error (deployment name was replaced by `*****`):

>│ Configuring AWS_ENDPOINT_URL:                                                                                                                                                                                                    │
│ Configuring AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY                                                                                                                                                                          │
│ awshelper downloading s3://*****-users/dev/user.yaml to /mnt/shared/user.yaml                                                                                                                                               │
│ Download attempt 0
│ fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden

# Analysis
The cause is that bucket `*****-users` does not exist so the users.yaml file cannot be downloaded from it. Instead a bucket named `gen3-users` is created.

# Solution
This PR will pass the users bucket name to the commons module via the _users_bucket_name_ parameter like so:

```
 users_bucket_name              = local.user_yaml_bucket_name
```