### PR TITLE
fix: set CloudWatch log retention, disable EC2 detailed monitoring, u…

### DIFF
--- a/tf_files/aws/modules/admin-vm/cloud.tf
+++ b/tf_files/aws/modules/admin-vm/cloud.tf
@@ -95,7 +95,7 @@ resource "aws_instance" "login" {
   ami                    = data.aws_ami.ubuntu.id
   subnet_id              = var.csoc_subnet_id
   instance_type          = "t2.micro"
-  monitoring             = true
+  monitoring             = false
   key_name               = var.ssh_key_name
   vpc_security_group_ids = [aws_security_group.ssh.id, aws_security_group.local.id]
   iam_instance_profile   = aws_iam_instance_profile.child_role_profile.name

--- a/tf_files/aws/modules/es-cloudwatch-alarm/main.tf
+++ b/tf_files/aws/modules/es-cloudwatch-alarm/main.tf
@@ -85,5 +85,6 @@ resource "aws_iam_role_policy" "lambda_es_cluster_red_policy" {
 }
 
 resource "aws_cloudwatch_log_group" "es_lambda" {
-  name            = "${var.vpc_name}-es-cluster-red-slack-alert"
+  name              = "${var.vpc_name}-es-cluster-red-slack-alert"
+  retention_in_days = 14
 }

--- a/tf_files/aws/modules/utility-vm/cloud.tf
+++ b/tf_files/aws/modules/utility-vm/cloud.tf
@@ -149,7 +149,7 @@ resource "aws_instance" "utility_vm" {
   ami                    = aws_ami_copy.cdis_ami.id
   subnet_id              = var.vpc_subnet_id
   instance_type          = var.instance_type
-  monitoring             = true
+  monitoring             = false
   key_name               = var.ssh_key_name
   vpc_security_group_ids = [aws_security_group.ssh.id, aws_security_group.local.id]
   iam_instance_profile   = aws_iam_instance_profile.vm_role_profile.name

--- a/tf_files/aws/nextflow_ami_pipeline/imagebuilder.tf
+++ b/tf_files/aws/nextflow_ami_pipeline/imagebuilder.tf
@@ -131,8 +131,8 @@ resource "aws_imagebuilder_image_recipe" "recipe" {
     ebs {
       delete_on_termination = true
       volume_size           = 30
-      volume_type           = "gp2"
-      encrypted = false
+      volume_type           = "gp3"
+      encrypted             = true
     }
   }
 

--- a/tf_files/aws/storage-gateway/cloud.tf
+++ b/tf_files/aws/storage-gateway/cloud.tf
@@ -24,7 +24,7 @@ resource "aws_instance" "storage-gw-server" {
   root_block_device {
     # Get volume size from var permanently
     volume_size = var.size
-    volume_type = "gp2"
+    volume_type = "gp3"
     encrypted   = true
   }
 


### PR DESCRIPTION
Addresses findings from the InfraScan cost analysis report:
https://infrascan.soldevelo.com/report/gen3-terraform-394cc80f-3788-4421-aeee-ad17422ee826

**Changes (active `tf_files/` only - deprecated modules untouched):**
- **CloudWatch Logs Without Retention** - Add `retention_in_days = 14` to `aws_cloudwatch_log_group "es_lambda"` in `modules/es-cloudwatch-alarm`. Without a retention policy, logs accumulate indefinitely at around $0.03/GB/month.
- **EC2 Detailed Monitoring** - Set `monitoring = false` in `modules/admin-vm` and `modules/utility-vm`. Detailed 1-minute metrics cost around $2-3/month per instance; standard 5-minute monitoring remains active.
- **Old Generation Storage (gp2)** - Migrate `volume_type` from `gp2` to `gp3` in `nextflow_ami_pipeline/imagebuilder.tf` and `storage-gateway/cloud.tf`. gp3 is around 20% cheaper and offers better baseline performance. Estimated saving: **$10-30/month per volume**.
- **Unencrypted EBS Volume** - Set `encrypted = true` on the imagebuilder EBS volume in `nextflow_ami_pipeline/imagebuilder.tf` (was explicitly set to `false`). Combined with the gp2 -> gp3 change above.

**Not addressed (require maintainer review):**
- **Old Generation Instance** - `t2.micro`/`t2.medium` in `admin-vm`, `squidnlb`, and others. Upgrading to `t3` equivalents would save **$10-50/month per instance** but requires validation.
- **Expensive NAT Gateway** - 2 NAT Gateways in `modules/vpc`. Likely needed; consolidation is an architectural trade-off.
- **Load Balancer for Single Instance** - Load balancers in `squidnlb`, `vpn_nlb_central_csoc`, `squid_nlb_central_csoc`. Each serves an active service; fixed cost around $15-25/month each.
- **SQS Max Message Retention** - 14-day retention in `modules/sqs`. Reducing it is a business logic decision.
- **Missing AWS Budget** - 44 occurrences across modules. This is an org-level governance concern, not addressable at the module level.