### PR TITLE
fix(whitelist): getting EOF on hitting zendesk.com

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -152,3 +152,4 @@ www.rabbitmq.com
 www.uniprot.org
 vpodc.org
 yahoo.com
+zendesk.com


### PR DESCRIPTION
https://cdis.slack.com/archives/C01EEN7LW1E/p1786388016793729

^ context, zendesk.com getting blocked.
